### PR TITLE
Fix typo at RedmineBackupRestore section.

### DIFF
--- a/docs/RedmineBackupRestore.md
+++ b/docs/RedmineBackupRestore.md
@@ -34,7 +34,7 @@ Redmineのバックアップとリストア
 /usr/bin/pg_dump -U <username> -h <hostname> -Fc --file=redmine.sqlc <redmine_database>
 ```
 
-`ユーザー名`、`パスワード`、`ホスト名`、`データベース名` は `config/database.yml` を見て調べることができます。MySQLのインストールの形態によっては `ホスト名` は不要なことがあります。データベースのパスワードは `pg_dump` コマンドを実行したときに入力を求められます。
+`ユーザー名`、`パスワード`、`ホスト名`、`データベース名` は `config/database.yml` を見て調べることができます。PostgreSQLのインストールの形態によっては `ホスト名` は不要なことがあります。データベースのパスワードは `pg_dump` コマンドを実行したときに入力を求められます。
 
 #### SQLite
 


### PR DESCRIPTION
s/MySQL/PostgreSQL/ in heading of PostgreSQL.

Signed-off-by: Noriki Nakamura <noriki.nakamura@miraclelinux.com>